### PR TITLE
Add scroll-driven Mission animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ npm install
 npm run dev
 ```
 
+To run lint checks, first install dev dependencies:
+
+```bash
+npm install
+npm run lint
+```
+
 To build:
 
 ```bash

--- a/src/components/features/Mission.jsx
+++ b/src/components/features/Mission.jsx
@@ -89,10 +89,10 @@ const HeroScroll = forwardRef(({ isActive, onCanLeaveChange }, ref) => {
 
       setTimeout(() => {
         isThrottled.current = false;
-        if (next === finalStage) onCanLeaveChange(true);
+        if (next === finalStage || next === 0) onCanLeaveChange(true);
       }, delay);
 
-      if (dir < 0) onCanLeaveChange(false);
+      if (dir < 0 && next !== 0) onCanLeaveChange(false);
       setStage(next);
     };
 
@@ -186,7 +186,7 @@ const HeroScroll = forwardRef(({ isActive, onCanLeaveChange }, ref) => {
             <Chart title="Competitors" targetAmount={75000} targetPercent={70} barColor="#ffffff" />
           </div>
         </motion.div>
-      </div>
+      </motion.div>
 
       <div className="w-full flex flex-col-reverse lg:flex-row items-center px-0 relative">
         <motion.div

--- a/src/components/ui/Chart.jsx
+++ b/src/components/ui/Chart.jsx
@@ -89,7 +89,7 @@ export default function Chart({
             transition={{ duration: 1, ease: "easeOut" }}
             className="text-3xl font-bold text-white"
           >
-            ${amount.toLocaleString()}
+            {`$${amount.toLocaleString()}`}
           </motion.span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- animate Mission section through scroll-driven stages
- lock section navigation until animation is complete on desktop

## Testing
- `npm run lint` *(fails: many unused variable errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f629391fc832283d38abeadec013a