### PR TITLE
Improve animations and scroll behavior

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,7 +38,7 @@ export default function App() {
   
     setTimeout(() => {
       isThrottled.current = false;
-    }, 800); // debounce duration
+    }, 300); // debounce duration shortened
   };
 
   const jumpToSection = (index) => {

--- a/src/components/common/FadeInUp.jsx
+++ b/src/components/common/FadeInUp.jsx
@@ -1,0 +1,26 @@
+import { motion, useInView } from "framer-motion";
+import { useRef } from "react";
+
+export default function FadeInUp({ children, distance = 20, className = "" }) {
+  const ref = useRef(null);
+  const inView = useInView(ref, { once: true, margin: "-100px" });
+
+  const variants = {
+    hidden: { opacity: 0, y: distance },
+    visible: { opacity: 1, y: 0 },
+  };
+
+  return (
+    <motion.div
+      ref={ref}
+      initial="hidden"
+      animate={inView ? "visible" : "hidden"}
+      variants={variants}
+      transition={{ duration: 0.8, ease: "easeOut" }}
+      className={className}
+      style={{ opacity: 0 }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/features/Footer.jsx
+++ b/src/components/features/Footer.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Instagram, Linkedin } from 'lucide-react';
+import FadeInUp from "../common/FadeInUp";
 import logoUrl from "../../assets/branding/vastro_full_logo.svg";
 import glowLeft from "../../assets/effects/glow_left.png";
 import glowRight from "../../assets/effects/glow_right.png";
@@ -20,18 +21,18 @@ export default function Footer() {
       />
 
       {/* Logo and email */}
-      <div className="container mx-auto flex flex-col items-center justify-center relative z-10 mt-12">
+      <FadeInUp className="container mx-auto flex flex-col items-center justify-center relative z-10 mt-12">
         <img src={logoUrl} alt="Vastro logo" className="mb-2 h-16 w-auto" />
         <p className="text-sm">info@vastro.org</p>
-      </div>
+      </FadeInUp>
 
       {/* Website credit */}
-      <div className="absolute bottom-10 left-1/2 transform -translate-x-1/2 text-xs opacity-70 z-10">
+      <FadeInUp className="absolute bottom-10 left-1/2 transform -translate-x-1/2 text-xs opacity-70 z-10">
         Website by Lucas Kover Wolf
-      </div>
+      </FadeInUp>
 
       {/* Social bar */}
-      <div className="absolute bottom-6 right-6 z-10">
+      <FadeInUp className="absolute bottom-6 right-6 z-10">
         <div className="flex space-x-4 bg-gray-800 bg-opacity-75 rounded-full px-4 py-2 items-center">
           <a href="https://instagram.com/vastro" aria-label="Instagram">
             <Instagram size={20} />
@@ -40,7 +41,7 @@ export default function Footer() {
             <Linkedin size={20} />
           </a>
         </div>
-      </div>
+      </FadeInUp>
     </footer>
   );
 }

--- a/src/components/features/Mission.jsx
+++ b/src/components/features/Mission.jsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { forwardRef, useRef } from "react";
-import { motion, useInView } from "framer-motion";
+import { forwardRef, useRef, useEffect } from "react";
+import { motion, useInView, useAnimation } from "framer-motion";
 import Glow from "../ui/Glow";
 import Chart from "../ui/Chart";
 import ComparisonTable from "../ui/ComparisonTable";
@@ -21,40 +21,69 @@ const variants = {
     hidden: { opacity: 0 },
     visible: { opacity: 1, transition: { duration: 1.2, delay: 1 } },
   },
-  banner: {
-    hidden: { x: -200, opacity: 0 },
-    visible: { x: 0, opacity: 1, transition: { duration: 0.8, ease: "easeOut" } },
-  },
   chart: {
     hidden: { opacity: 0, scale: 0.9 },
     visible: { opacity: 1, scale: 1, transition: { duration: 0.8, ease: "easeOut" } },
   },
-  bannerRight: {
-    hidden: { x: 200, opacity: 0 },
-    visible: { x: 0, opacity: 1, transition: { duration: 0.8, ease: "easeOut" } },
-  },
 };
 
 const HeroScroll = forwardRef((_, ref) => {
-  const containerRef = useRef(null);
-  const inView = useInView(containerRef, { once: true, margin: "-100px" });
+  const bannerControls = useAnimation();
+  const chartControls = useAnimation();
+  const firstWrapControls = useAnimation();
+  const secondBannerControls = useAnimation();
+  const secondSectionRef = useRef(null);
+  const secondInView = useInView(secondSectionRef, { margin: "-50% 0px", once: true });
+
+  useEffect(() => {
+    async function run() {
+      firstWrapControls.start({ opacity: 1 });
+      await bannerControls.start({
+        x: 0,
+        opacity: 1,
+        scaleX: [1.05, 1],
+        transition: { type: "spring", stiffness: 70, damping: 12 },
+      });
+      chartControls.start("visible");
+    }
+    run();
+  }, [bannerControls, chartControls, firstWrapControls]);
+
+  useEffect(() => {
+    if (secondInView) {
+      firstWrapControls.start({
+        y: "-25vh",
+        scale: 0.5,
+        transition: { duration: 1, ease: "easeInOut" },
+      });
+      secondBannerControls.start({
+        x: 0,
+        opacity: 1,
+        scaleX: [1.05, 1],
+        transition: { type: "spring", stiffness: 70, damping: 12, delay: 0.2 },
+      });
+    }
+  }, [secondInView, firstWrapControls, secondBannerControls]);
 
   return (
     <div className="py-6 space-y-10">
       {/* First Section: Left Banner + Charts */}
-      <div ref={ref} className="w-full flex flex-col lg:flex-row items-center px-0">
+      <motion.div
+        ref={ref}
+        className="w-full flex flex-col lg:flex-row items-center px-0"
+        style={{ opacity: 0 }}
+        animate={firstWrapControls}
+      >
         <motion.div
-          ref={containerRef}
-          initial="hidden"
-          animate={inView ? "visible" : "hidden"}
-          variants={variants.banner}
+          initial={{ x: "100%", opacity: 0 }}
+          animate={bannerControls}
           className="bg-black w-full lg:w-[70%] flex flex-col items-center justify-center relative rounded-r-3xl px-20 py-24 my-6"
           style={{ boxShadow: "0 0 20px rgba(255,255,255,0.15)" }}
         >
           <motion.div
             variants={variants.glow}
             initial="hidden"
-            animate={inView ? "visible" : "hidden"}
+            animate="visible"
             className="absolute inset-0 flex items-center justify-center pointer-events-none"
           >
             <Glow color="white" />
@@ -63,8 +92,8 @@ const HeroScroll = forwardRef((_, ref) => {
           <motion.div
             className="relative z-10 text-center font-bold text-white whitespace-nowrap text-[3vw] leading-[1.1]"
             initial="hidden"
-            animate={inView ? "visible" : "hidden"} 
-          >   
+            animate="visible"
+          >
             VR‑controlled quadruped robots<br />
             $75k capability for $2.5k
           </motion.div>
@@ -73,44 +102,39 @@ const HeroScroll = forwardRef((_, ref) => {
         <motion.div
           className="w-full lg:w-[30%] flex flex-col justify-center items-center"
           initial="hidden"
-          animate={inView ? "visible" : "hidden"}
+          animate={chartControls}
           variants={variants.chart}
         >
           <div className="flex flex-col lg:flex-col md:flex-row gap-10 justify-center items-center w-full">
             <Chart title="VASTRO" targetAmount={2500} targetPercent={2.5} barColor="#ffffff" />
             <Chart title="Competitors" targetAmount={75000} targetPercent={70} barColor="#ffffff" />
           </div>
-        </motion.div> 
-      </div>
-
-      {/* Second Section: Table Left + Right Banner */}
-      <div className="w-full flex flex-col-reverse lg:flex-row items-center px-0">
-      <motion.div 
-        className="w-full lg:w-[40%] flex justify-center items-center px-6 py-0"
-        initial="hidden"
-        animate={inView ? "visible" : "hidden"}
-        variants={variants.chart}
-      >
-        <div className="w-full mx-15">
-          <ComparisonTable
-            data={specs}
-            labelLeft="SpotMini"
-            labelRight="VASTRO"
-          />
-        </div>
+        </motion.div>
       </motion.div>
 
-        <motion.div 
+      {/* Second Section: Table Left + Right Banner */}
+      <motion.div ref={secondSectionRef} className="w-full flex flex-col-reverse lg:flex-row items-center px-0">
+        <motion.div
+          className="w-full lg:w-[40%] flex justify-center items-center px-6 py-0"
           initial="hidden"
-          animate={inView ? "visible" : "hidden"}
-          variants={variants.bannerRight}
+          animate={secondInView ? "visible" : "hidden"}
+          variants={variants.chart}
+        >
+          <div className="w-full mx-15">
+            <ComparisonTable data={specs} labelLeft="SpotMini" labelRight="VASTRO" />
+          </div>
+        </motion.div>
+
+        <motion.div
+          initial={{ x: "100%", opacity: 0 }}
+          animate={secondBannerControls}
           className="bg-black w-full lg:w-[60%] flex flex-col items-center justify-center relative rounded-l-3xl px-20 py-32"
           style={{ boxShadow: "0 0 20px rgba(255,255,255,0.15)" }}
         >
           <motion.div
             variants={variants.glow}
             initial="hidden"
-            animate={inView ? "visible" : "hidden"}
+            animate="visible"
             className="absolute inset-0 flex items-center justify-center pointer-events-none"
           >
             <Glow color="white" />
@@ -119,14 +143,14 @@ const HeroScroll = forwardRef((_, ref) => {
           <motion.div
             className="relative z-10 text-center font-bold text-white whitespace-nowrap text-[3vw] leading-[1.1]"
             initial="hidden"
-            animate={inView ? "visible" : "hidden"}
+            animate="visible"
           >
             Making remote access<br />
             more accessible
           </motion.div>
         </motion.div>
-      </div>
-    </div   >
+      </motion.div>
+    </div>
   );
 });
 

--- a/src/components/layout/SectionWrapper.jsx
+++ b/src/components/layout/SectionWrapper.jsx
@@ -6,14 +6,25 @@ export default function SectionWrapper({ isActive, scrollDirection, children }) 
       {isActive && (
         <motion.div
           key="section"
-          initial={{ opacity: 0, y: 60 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: scrollDirection === "down" ? -60 : 60 }}
-          transition={{
-            duration: 1.2,
-            ease: [0.16, 1, 0.3, 1], // slow ease out
+          initial={{
+            opacity: 0,
+            y: scrollDirection === "down" ? 100 : -100,
+            scale: 0.96,
           }}
+          animate={{ opacity: 1, y: 0, scale: 1, rotateX: 0 }}
+          exit={{
+            opacity: [1, 1, 0],
+            y:
+              scrollDirection === "down"
+                ? [0, 30, -200, -600]
+                : [0, -30, 200, 600],
+            scale: [1, 0.98, 0.9, 0.8],
+            rotateX:
+              scrollDirection === "down" ? [0, -10, -20, -45] : [0, 10, 20, 45],
+          }}
+          transition={{ duration: 1.6, times: [0, 0.15, 0.5, 1], ease: "easeInOut" }}
           className="absolute inset-0"
+          style={{ perspective: 1200 }}
         >
           {children}
         </motion.div>

--- a/src/components/ui/Chart.jsx
+++ b/src/components/ui/Chart.jsx
@@ -44,7 +44,11 @@ export default function Chart({
   }, [inView, controls, targetStrokeOffset, targetAmount]);
 
   return (
-    <div ref={containerRef} className="flex flex-col items-center justify-center space-y-3">
+    <div
+      ref={containerRef}
+      className="flex flex-col items-center justify-center space-y-3"
+      style={{ opacity: 0 }}
+    >
       <div className="relative w-48 h-48">
         <svg className="w-full h-full transform -rotate-90" viewBox="0 0 100 100">
           <defs>

--- a/src/components/ui/ComparisonTable.jsx
+++ b/src/components/ui/ComparisonTable.jsx
@@ -1,49 +1,69 @@
+import { motion, useInView } from "framer-motion";
+import { useRef } from "react";
+
 export default function ComparisonTable({ data, labelLeft, labelRight, className = "" }) {
-    return (
-      <div className={`text-white w-full max-w-4xl mx-auto ${className}`}>
-        {/* Header Row */}
-        <div className="flex justify-between items-center pb-6">
-        <span className="text-sm font-medium  text-left text-gray-400 tracking-widest">
-        Specifications
-          </span>
-          <span className="text-sm font-medium text-center text-gray-400 tracking-widest">
-            
-            
-          </span>
-          <span className=" flex justify-end space-x-5 text-base font-black">
-                <span className="text-gray-400">{labelLeft}</span>
-                <span className="text-gray-600">/</span>
-                <span className="text-white">{labelRight}</span>
-              </span>
-        </div>
-  
-        {/* Data Rows */}
-        <div className="space-y-3">
-          {data.map((item, index) => (
-            <div
-              key={index}
-              className={`flex justify-between items-center pb-2 ${
-                index !== data.length - 1 ? "border-b border-white/30" : ""
-              }`}
-            >
-              {/* Specs on the left */}
-              <span className="text-sm text-gray-400 tracking-widest uppercase  text-left">
-                {item.label}
-              </span>
-  
-              {/* Empty center */}
-              <span className="" />
-  
-              {/* Spot / Vastro on right with 5x spacing */}
-              <span className=" flex justify-end space-x-5 text-base font-black">
-                <span className="text-gray-400">{item.left}</span>
-                <span className="text-gray-600">/</span>
-                <span className="text-white">{item.right}</span>
-              </span>
-            </div>
-          ))}
-        </div>
+  const containerRef = useRef(null);
+  const inView = useInView(containerRef, { once: true, margin: "-100px" });
+
+  const rowVariants = {
+    hidden: { opacity: 0, y: 15, scale: 0.95 },
+    visible: (i) => ({
+      opacity: 1,
+      y: 0,
+      scale: 1,
+      transition: { delay: i * 0.1, duration: 0.6, ease: "easeOut" },
+    }),
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={`text-white w-full max-w-4xl mx-auto ${className}`}
+      style={{ opacity: 0 }}
+    >
+      {/* Header Row */}
+      <div className="flex justify-between items-center pb-6">
+        <span className="text-sm font-medium text-left text-gray-400 tracking-widest">
+          Specifications
+        </span>
+        <span className="text-sm font-medium text-center text-gray-400 tracking-widest" />
+        <span className="flex justify-end space-x-5 text-base font-black">
+          <span className="text-gray-400">{labelLeft}</span>
+          <span className="text-gray-600">/</span>
+          <span className="text-white">{labelRight}</span>
+        </span>
       </div>
-    );
-  }
-  
+
+      {/* Data Rows */}
+      <div className="space-y-3">
+        {data.map((item, index) => (
+          <motion.div
+            key={index}
+            custom={index}
+            variants={rowVariants}
+            initial="hidden"
+            animate={inView ? "visible" : "hidden"}
+            className={`flex justify-between items-center pb-2 ${
+              index !== data.length - 1 ? "border-b border-white/30" : ""
+            }`}
+          >
+            {/* Specs on the left */}
+            <span className="text-sm text-gray-400 tracking-widest uppercase text-left">
+              {item.label}
+            </span>
+
+            {/* Empty center */}
+            <span className="" />
+
+            {/* Spot / Vastro on right with 5x spacing */}
+            <span className="flex justify-end space-x-5 text-base font-black">
+              <span className="text-gray-400">{item.left}</span>
+              <span className="text-gray-600">/</span>
+              <span className="text-white">{item.right}</span>
+            </span>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- hide fading elements until animations start
- shorten scroll throttle for easier reversing
- ensure charts and table remain hidden before reveal
- overhaul Mission banner animations with sequential entrance

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68402bceace083228f69c3e20e3abe2a