### PR TITLE
Enhance team carousel with details and animations

### DIFF
--- a/src/components/ui/TeamCarousel.jsx
+++ b/src/components/ui/TeamCarousel.jsx
@@ -108,7 +108,7 @@ export default function TeamCarousel() {
 
        useEffect(() => {
                setInfoVisible(false);
-               const timeout = setTimeout(() => setInfoVisible(true), 480);
+               const timeout = setTimeout(() => setInfoVisible(true), 240);
                return () => clearTimeout(timeout);
        }, [activeIndex]);
 
@@ -189,8 +189,8 @@ export default function TeamCarousel() {
                                                                                !isActive ? "filter grayscale" : ""
                                                                                }`}
                                                                                loading="lazy"
-                                                                               animate={{ scale: isActive ? 1.05 : 1 }}
-                                                                               transition={{ duration: 0.4, ease: "easeOut" }}
+                                                                               animate={{ scale: isActive ? 1.12 : 1 }}
+                                                                               transition={{ duration: 0.5, ease: "easeOut" }}
                                                                                />
 
 										{/* Static black overlay with bouncing arrow */}


### PR DESCRIPTION
## Summary
- add LinkedIn info for each team member
- animate profile image zoom when member active
- show LinkedIn icon beside position
- fade-in details overlay with dark gradient background

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68406844deb083228af39b23b9997dfa