### PR TITLE
Improve team carousel responsiveness

### DIFF
--- a/src/components/features/Team.jsx
+++ b/src/components/features/Team.jsx
@@ -38,7 +38,7 @@ export default function Team({ isActive, scrollDirection, onCanLeaveChange }) {
 
                 {/* Right side - Team carousel */}
                 <div className="lg:col-span-9 flex justify-center">
-                  <div className="w-[600px] transform scale-[0.8] lg:scale-[0.5]">
+                  <div className="team-carousel-wrapper">
                     <TeamCarousel />
                   </div>
                 </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -36,3 +36,21 @@ h1, h2, h3, h4, h5, h6 {
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
+
+/* Responsive scaling for the team carousel */
+.team-carousel-wrapper {
+  width: 600px;
+  transform-origin: top left;
+}
+
+@media (min-width: 1024px) {
+  .team-carousel-wrapper {
+    transform: scale(calc(min(50vw, 600px) / 600));
+  }
+}
+
+@media (max-width: 1023px) {
+  .team-carousel-wrapper {
+    transform: scale(calc(min(80vw, 600px) / 600));
+  }
+}


### PR DESCRIPTION
## Summary
- adjust layout of Team section so the carousel scales as a single unit

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68407ebdee188322ae8dc74d839aab8c