### PR TITLE
Replace mission with stage-based scrolling

### DIFF
--- a/src/components/features/Mission.jsx
+++ b/src/components/features/Mission.jsx
@@ -6,9 +6,9 @@ import StageBanner from "./StageBanner";
 const components = [StageBanner, StageBanner, StageBanner];
 
 const baseParams = [
-  { direction: 0 },
-  { direction: 1 },
-  { direction: 0 },
+  { direction: 0, thickness: 50 },
+  { direction: 1, thickness: 50 },
+  { direction: 0, thickness: 50 },
 ];
 
 const stages = [

--- a/src/components/features/StageBanner.jsx
+++ b/src/components/features/StageBanner.jsx
@@ -2,12 +2,14 @@
 
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
+import Glow from "../ui/Glow";
 
 export default function StageBanner({
   direction = 0,
   text,
   start = 0,
   end = 100,
+  thickness = 50,
   show,
 }) {
   const [isMobile, setIsMobile] = useState(false);
@@ -20,25 +22,33 @@ export default function StageBanner({
   }, []);
 
   const lenKey = isMobile ? "height" : "width";
+  const crossKey = isMobile ? "width" : "height";
   const variants = {
     hidden: {
       x: direction === 0 ? -200 : 200,
       opacity: 0,
       [lenKey]: `${start}%`,
+      [crossKey]: `${thickness}%`,
       transition: { duration: 0.8, ease: "easeOut" },
     },
     visible: {
       x: 0,
       opacity: 1,
       [lenKey]: `${end}%`,
+      [crossKey]: `${thickness}%`,
       transition: { duration: 0.8, ease: "easeOut" },
     },
   };
 
   const style = isMobile
-    ? { width: "100%", left: 0, top: 0 }
+    ? {
+        [crossKey]: `${thickness}%`,
+        left: direction === 0 ? 0 : "auto",
+        right: direction === 1 ? 0 : "auto",
+        top: 0,
+      }
     : {
-        height: "50vh",
+        [crossKey]: `${thickness}%`,
         top: "50%",
         transform: "translateY(-50%)",
         left: direction === 0 ? 0 : "auto",
@@ -47,13 +57,20 @@ export default function StageBanner({
 
   return (
     <motion.div
-      className="absolute flex items-center justify-center bg-black text-white font-bold p-4 overflow-hidden"
-      style={style}
+      className={`absolute flex items-center justify-center bg-black text-white font-bold px-6 overflow-hidden my-6 ${
+        direction === 0 ? "rounded-r-3xl" : "rounded-l-3xl"
+      }`}
+      style={{ ...style, boxShadow: "0 0 20px rgba(255,255,255,0.15)" }}
       variants={variants}
       initial="hidden"
       animate={show ? "visible" : "hidden"}
     >
-      <span className="text-center text-3xl">{text}</span>
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <Glow color="white" />
+      </div>
+      <span className="relative z-10 text-center whitespace-nowrap leading-tight text-[8vw] md:text-[3vw]">
+        {text}
+      </span>
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- add StagePlaceholder component for the upcoming content
- implement new Mission section with internal stage navigation via scroll

## Testing
- `npm run lint` *(fails: 15 errors, 13 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684090fab1248322bd8c776c9adfe1d3