### PR TITLE
Improve section entrance/exit animations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,6 +68,7 @@ export default function App() {
             <SectionWrapper
               isActive={i === activeIndex}
               scrollDirection={scrollDirection}
+              skipInitialAnimation={i === 0}
             >
               <Suspense fallback={i === 0 ? null : <Loading />}>
                 <Section

--- a/src/components/features/Team.jsx
+++ b/src/components/features/Team.jsx
@@ -23,23 +23,21 @@ export default function Team({ isActive, scrollDirection, onCanLeaveChange }) {
           className="w-full h-full bg-black text-white overflow-hidden"
         >
           <main className="min-h-screen flex items-center justify-center">
-            <div className="max-w-7xl mx-auto py-20 px-4 md:px-8 lg:px-16 w-full">
-              <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
-                {/* Left side - Text content */}
-                <div className="lg:col-span-3 flex flex-col justify-center">
-                  <h2 className="text-4xl md:text-5xl font-bold mb-6">Team</h2>
+            <div className="max-w-7xl mx-auto py-20 px-4 md:px-8 lg:px-16 w-full flex flex-col-reverse md:flex-row items-center md:items-start md:justify-center gap-8 my-8">
+              {/* Left side - Text content */}
+              <div className="w-full md:w-1/2 flex flex-col items-center md:items-start text-center md:text-left">
+                <h2 className="text-4xl md:text-5xl font-bold mb-6">Team</h2>
 
-                  <div className="w-full h-12 bg-gradient-to-r from-purple-500 to-pink-500 rounded-md mb-6" />
+                <div className="w-full h-12 bg-gradient-to-r from-purple-500 to-pink-500 rounded-md mb-6" />
 
-                  <p className="text-lg text-gray-300 mb-4">
-                    We are a small team of Brown University students passionate about creating innovative solutions.
-                  </p>
-                </div>
+                <p className="text-lg text-gray-300 mb-4">
+                  We are a small team of Brown University students passionate about creating innovative solutions.
+                </p>
+              </div>
 
-                {/* Right side - Team carousel */}
-                <div className="lg:col-span-9">
-                  <TeamCarousel />
-                </div>
+              {/* Right side - Team carousel */}
+              <div className="w-full md:w-1/2 flex justify-center">
+                <TeamCarousel />
               </div>
             </div>
           </main>

--- a/src/components/layout/SectionWrapper.jsx
+++ b/src/components/layout/SectionWrapper.jsx
@@ -1,12 +1,31 @@
 import { AnimatePresence, motion } from "framer-motion";
+import { useRef, useEffect } from "react";
 
-export default function SectionWrapper({ isActive, scrollDirection, children }) {
+export default function SectionWrapper({
+  isActive,
+  scrollDirection,
+  skipInitialAnimation = false,
+  children,
+}) {
+  const hasEnteredRef = useRef(false);
+
+  useEffect(() => {
+    if (isActive && !hasEnteredRef.current) {
+      hasEnteredRef.current = true;
+    }
+  }, [isActive]);
+
+  const initialProps =
+    skipInitialAnimation && !hasEnteredRef.current
+      ? false
+      : { opacity: 0, y: scrollDirection === "down" ? 60 : -60 };
+
   return (
     <AnimatePresence mode="wait">
       {isActive && (
         <motion.div
           key="section"
-          initial={{ opacity: 0, y: 60 }}
+          initial={initialProps}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: scrollDirection === "down" ? -60 : 60 }}
           transition={{

--- a/src/components/ui/TeamCarousel.jsx
+++ b/src/components/ui/TeamCarousel.jsx
@@ -138,15 +138,15 @@ export default function TeamCarousel() {
 	const visibleMembers = getVisibleMembers();
 
 	return (
-		<div
-			className="relative h-[600px] w-full overflow-hidden"
-			onMouseMove={() => setLastInteraction(Date.now())}
-		>
-			<AnimatePresence mode="popLayout">
-				<div
-					ref={carouselRef}
-					className="flex justify-end gap-3 h-[550px] w-full absolute"
-				>
+                <div
+                        className="relative w-full overflow-hidden aspect-[4/3]"
+                        onMouseMove={() => setLastInteraction(Date.now())}
+                >
+                        <AnimatePresence mode="popLayout">
+                                <div
+                                        ref={carouselRef}
+                                        className="absolute inset-0 flex justify-end gap-3"
+                                >
 					{visibleMembers.map((member, index) => {
 						const isRightmost = index === 4;
 						const isActive = index === activeIndex;
@@ -154,9 +154,9 @@ export default function TeamCarousel() {
 						return (
 							<motion.div
 								key={`${member.id}-${member.visibleIndex}`}
-								className={`relative cursor-pointer ${
-									isActive ? "h-[600px]" : "h-[550px]"
-								}`}
+                                                                className={`relative cursor-pointer ${
+                                                                        isActive ? "h-full" : "h-[92%]"
+                                                                }`}
 								style={{
 									zIndex: isActive ? 10 : 1,
 								}}
@@ -164,7 +164,7 @@ export default function TeamCarousel() {
 								animate={{
 									opacity: 1,
 									x: 0,
-									flex: isActive ? "1 0 150px" : "0 0 60px",
+                                                                        flex: isActive ? "1 0 18.75%" : "0 0 7.5%",
 									marginLeft: isActive ? "8px" : "0px",
 									marginRight: isActive ? "8px" : "0px",
 								}}


### PR DESCRIPTION
## Summary
- skip initial animation for the Home section so it's visible on load
- enter new sections from the correct direction based on scroll

## Testing
- `npm install`
- `npm run lint` *(fails: pre-existing repository lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68409924d1f48322b2f6c5add7eccd4f