### PR TITLE
Refine team carousel sizing

### DIFF
--- a/src/components/ui/TeamCarousel.jsx
+++ b/src/components/ui/TeamCarousel.jsx
@@ -137,37 +137,36 @@ export default function TeamCarousel() {
 
 	const visibleMembers = getVisibleMembers();
 
-	return (
-		<div
-			className="relative h-[600px] w-full overflow-hidden"
-			onMouseMove={() => setLastInteraction(Date.now())}
-		>
+        return (
+                <div
+                        className="relative w-full overflow-hidden h-[420px] sm:h-[480px] md:h-[520px] lg:h-[600px]"
+                        onMouseMove={() => setLastInteraction(Date.now())}
+                >
 			<AnimatePresence mode="popLayout">
-				<div
-					ref={carouselRef}
-					className="flex justify-end gap-3 h-[550px] w-full absolute"
-				>
+                                <div
+                                        ref={carouselRef}
+                                        className="flex justify-end gap-3 h-full w-full absolute"
+                                >
 					{visibleMembers.map((member, index) => {
 						const isRightmost = index === 4;
 						const isActive = index === activeIndex;
 
 						return (
-							<motion.div
-								key={`${member.id}-${member.visibleIndex}`}
-								className={`relative cursor-pointer ${
-									isActive ? "h-[600px]" : "h-[550px]"
-								}`}
-								style={{
-									zIndex: isActive ? 10 : 1,
-								}}
+                                                        <motion.div
+                                                                key={`${member.id}-${member.visibleIndex}`}
+                                                                className="relative cursor-pointer h-full flex-none"
+                                                                style={{
+                                                                        zIndex: isActive ? 10 : 1,
+                                                                        aspectRatio: isActive ? "150 / 600" : "60 / 550",
+                                                                }}
 								initial={{ opacity: 1, x: 50 }}
-								animate={{
-									opacity: 1,
-									x: 0,
-									flex: isActive ? "1 0 150px" : "0 0 60px",
-									marginLeft: isActive ? "8px" : "0px",
-									marginRight: isActive ? "8px" : "0px",
-								}}
+                                                                animate={{
+                                                                        opacity: 1,
+                                                                        x: 0,
+                                                                        scale: isActive ? 1 : 0.8,
+                                                                        marginLeft: isActive ? "8px" : "0px",
+                                                                        marginRight: isActive ? "8px" : "0px",
+                                                                }}
 								exit={{ x: -50, opacity: 0 }}
                                                                transition={{
                                                                        duration: 0.6,
@@ -226,8 +225,8 @@ export default function TeamCarousel() {
 										)}
 
 										{!isActive && (
-											<div className="absolute inset-0 flex items-end justify-center pb-20">
-												<div className="rotate-[-90deg] origin-center whitespace-nowrap text-3xl font-bold text-white tracking-wide">
+                                       <div className="absolute inset-0 flex items-end justify-center pb-20">
+                                       <div className="rotate-[-90deg] origin-center whitespace-nowrap text-xl sm:text-2xl md:text-3xl font-bold text-white tracking-wide">
 													{member.name.split(" ")[0]}
 												</div>
 											</div>
@@ -242,10 +241,10 @@ export default function TeamCarousel() {
                                                 transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
                                         >
                                                 <div className="absolute inset-0 p-6 bg-gradient-to-t from-black/90 via-black/70 to-transparent space-y-2 pointer-events-auto">
-                                                        <h3 className="text-3xl font-bold text-white whitespace-nowrap">
+                                                        <h3 className="font-bold text-white whitespace-nowrap text-xl sm:text-2xl md:text-3xl lg:text-3xl">
                                                                 {member.name}
                                                         </h3>
-                                                        <div className="flex items-center text-xl font-semibold text-gray-200 space-x-2">
+                                                        <div className="flex items-center font-semibold text-gray-200 space-x-2 text-sm sm:text-base md:text-lg lg:text-xl">
                                                                 <span>{member.role}</span>
                                                                 <div className="flex items-center space-x-1 pl-3 text-gray-400">
                                                                         <a
@@ -253,7 +252,7 @@ export default function TeamCarousel() {
                                                                                 aria-label="Email"
                                                                                 className="p-1 text-gray-400 hover:text-white"
                                                                         >
-                                                                                <Mail className="w-5 h-5" />
+                                                                        <Mail className="w-4 h-4 sm:w-5 sm:h-5 lg:w-6 lg:h-6" />
                                                                         </a>
                                                                         <a
                                                                                 href={member.linkedin}
@@ -262,11 +261,11 @@ export default function TeamCarousel() {
                                                                                 aria-label="LinkedIn"
                                                                                 className="p-1 text-gray-400 hover:text-white"
                                                                         >
-                                                                                <Linkedin className="w-5 h-5" />
+                                                                        <Linkedin className="w-4 h-4 sm:w-5 sm:h-5 lg:w-6 lg:h-6" />
                                                                         </a>
                                                                 </div>
                                                         </div>
-                                                        <p className="text-base text-gray-400 whitespace-pre-line">
+                                                        <p className="text-sm sm:text-base md:text-base lg:text-lg text-gray-400 whitespace-pre-line">
                                                                 {member.bio}
                                                         </p>
                                                 </div>


### PR DESCRIPTION
## Summary
- tweak TeamCarousel to maintain aspect ratio for cards
- make info text and icons scale with card size

## Testing
- `npm run lint` *(fails: several lint errors not introduced in this PR)*

------
https://chatgpt.com/codex/tasks/task_e_68416a20343883228c75b203ff16fa7b